### PR TITLE
Add a github actions reporter: adds a step summary table + annotations for minitest

### DIFF
--- a/lib/openstudio_measure_tester.rb
+++ b/lib/openstudio_measure_tester.rb
@@ -11,6 +11,7 @@ require 'pp'
 require 'rexml/document'
 require 'minitest'
 require 'simplecov'
+require 'json'
 
 begin
   require 'git'

--- a/lib/openstudio_measure_tester.rb
+++ b/lib/openstudio_measure_tester.rb
@@ -36,6 +36,7 @@ require_relative 'openstudio_measure_tester/coverage'
 require_relative 'openstudio_measure_tester/rubocop_result'
 require_relative 'openstudio_measure_tester/openstudio_testing_result'
 require_relative 'openstudio_measure_tester/dashboard'
+require_relative 'openstudio_measure_tester/github_actions_report'
 require_relative 'openstudio_measure_tester/runner'
 
 require_relative 'openstudio_measure_tester/rake_task'

--- a/lib/openstudio_measure_tester/github_actions_report.rb
+++ b/lib/openstudio_measure_tester/github_actions_report.rb
@@ -5,9 +5,6 @@
 # See also https://openstudio.net/license
 # *******************************************************************************
 
-require 'json'
-require 'rexml'
-
 module OpenStudioMeasureTester
   class GithubActionsReport
     attr_reader :minitest_summary_table, :all_annotations

--- a/lib/openstudio_measure_tester/github_actions_report.rb
+++ b/lib/openstudio_measure_tester/github_actions_report.rb
@@ -20,7 +20,7 @@ module OpenStudioMeasureTester
 
     def write_step_summary(msg)
       puts msg
-      if !ENV['GITHUB_ACTIONS'].nil?
+      if !ENV['GITHUB_STEP_SUMMARY'].nil?
         File.write(ENV['GITHUB_STEP_SUMMARY'], "#{msg}\n", mode: 'a+')
       end
     end

--- a/lib/openstudio_measure_tester/github_actions_report.rb
+++ b/lib/openstudio_measure_tester/github_actions_report.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# *******************************************************************************
+# OpenStudio(R), Copyright (c) Alliance for Sustainable Energy, LLC.
+# See also https://openstudio.net/license
+# *******************************************************************************
+
+require 'json'
+require 'rexml'
+
+module OpenStudioMeasureTester
+  class GithubActionsReport
+    attr_reader :html
+
+    # @param test_results_directory [String]: The directory
+    def initialize(test_results_directory)
+      @test_results_directory = test_results_directory
+      file = File.read("#{@test_results_directory}/combined_results.json")
+      @hash = JSON.parse(file)
+    end
+
+    def write_step_summary(msg)
+      puts msg
+      if !ENV['GITHUB_ACTIONS'].nil?
+        File.write(ENV['GITHUB_STEP_SUMMARY'], "#{msg}\n", mode: 'a+')
+      end
+    end
+
+    def hash_to_markdown(h, header0, header1)
+      n0 = [h.keys.map(&:to_s).map(&:size).max, header0.size].max
+      n1 = [h.values.map(&:to_s).map(&:size).max, header1.size].max
+
+      content = [
+        "| #{header0.ljust(n0)} | #{header1.ljust(n1)} |",
+        "| " + "-" * n0 + " | " + "-" * n1 + " |",
+      ] + h.map{|k, v| "| #{k.ljust(n0)} | #{v.to_s.ljust(n1)} |"}
+      return content.join("\n")
+    end
+
+    def make_minitest_step_summary_table
+
+      write_step_summary("## Minitest")
+      write_step_summary("")
+
+      total_tests = @hash['minitest']['total_tests']
+      total_assertions = @hash['minitest']['total_assertions']
+      total_errors = @hash['minitest']['total_errors']
+      total_failures = @hash['minitest']['total_failures']
+      total_skipped = @hash['minitest']['total_skipped']
+      total_compatibility_errors = @hash['minitest']['total_compatibility_errors']
+      total_load_errors = @hash['minitest']['total_load_errors'].count
+
+      passed = total_tests - (total_failures + total_errors + total_skipped)
+      pct = passed.to_f / (total_tests - total_skipped).to_f
+
+      h = {
+        'Total Tests' => total_tests,
+        'Load Error' => total_load_errors,
+        'Passed' => passed,
+        'Success Rate' => '%.2f%%' % (pct * 100.0),
+        'Failures' => total_failures,
+        'Errors' => total_errors,
+        'Skipped' => total_skipped,
+        'Incompatible' => total_compatibility_errors,
+        'Total Assertions' => total_assertions,
+      }
+
+      @minitest_summary_table = hash_to_markdown(h, "Metric", "Value")
+
+      write_step_summary(@minitest_summary_table)
+      write_step_summary("")
+    end
+
+    def make_minitest_annotations
+      report_xmls = Dir["#{@test_results_directory}/minitest/reports/TEST-*.xml"]
+      report_xmls.each do |report_xml|
+        doc = REXML::Document.new(File.open(report_xml)).root
+        testsuite_element = doc.elements['testsuite']
+        filepath = testsuite_element.attributes['filepath']
+        testsuite_element.elements.each('testcase') do |testcase|
+          test_name = testcase.attributes['name']
+          line = testcase.attributes['lineno'].to_i
+          tested_class = testcase.attributes['classname']
+
+          testcase.elements.each('failure') do |x|
+            title = x.attributes['type']
+            message = x.attributes['message']
+            puts "::error file=#{filepath},line=#{line},endLine=#{line + 1},title=#{title}::#{tested_class}.#{test_name}: #{message}"
+          end
+          testcase.elements.each('error') do |x|
+            title = x.attributes['type']
+            message = x.attributes['message']
+            puts "::error file=#{filepath},line=#{line},endLine=#{line + 1},title=#{title}::#{message}"
+          end
+          testcase.elements.each('skipped') do |x|
+            title = x.attributes['type']
+            message = x.attributes['message']
+            puts "::warning file=#{filepath},line=#{line},endLine=#{line + 1},title=#{title}::#{message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/openstudio_measure_tester/rake_task.rb
+++ b/lib/openstudio_measure_tester/rake_task.rb
@@ -27,7 +27,7 @@ module OpenStudioMeasureTester
     def setup_subtasks(name)
       namespace name do
         ####################################### Minitest and Coverage #######################################
-        desc 'new test task'
+        desc 'Run Minitest and Coverage on Measures'
         task :test do
           runner = OpenStudioMeasureTester::Runner.new(Rake.application.original_dir)
           # Need to pass in the current directory because the results of minitest and coverage end up going into

--- a/lib/openstudio_measure_tester/rubocop_result.rb
+++ b/lib/openstudio_measure_tester/rubocop_result.rb
@@ -90,7 +90,8 @@ module OpenStudioMeasureTester
           doc.elements.each('//checkstyle/file') do |rc_file|
             # Allow processing when the file is just the measure.rb
             if rc_file.attributes['name'] != 'measure.rb'
-              if !rc_file.attributes['name'].include? measure_name
+              parts = rc_file.attributes['name'].split(File::SEPARATOR)
+              if !parts.include? measure_name
                 next
               end
             end

--- a/lib/openstudio_measure_tester/runner.rb
+++ b/lib/openstudio_measure_tester/runner.rb
@@ -32,6 +32,12 @@ module OpenStudioMeasureTester
       template.render
     end
 
+    def github_actions_report
+      gha_reporter = OpenStudioMeasureTester::GithubActionsReport.new(test_results_dir)
+      gha_reporter.make_minitest_step_summary_table
+      gha_reporter.make_minitest_annotations
+    end
+
     # Prepare the current directory and the root directory to remove old test results before running
     # the new tests
     #
@@ -95,6 +101,8 @@ module OpenStudioMeasureTester
 
       # call the create dashboard command now that we have results
       dashboard
+
+      github_actions_report if ENV["GITHUB_ACTIONS"]
 
       # return the results exit code
       return results.exit_code

--- a/lib/openstudio_measure_tester/runner.rb
+++ b/lib/openstudio_measure_tester/runner.rb
@@ -73,8 +73,10 @@ module OpenStudioMeasureTester
       # copy over the .rubocop.yml file into the root directory of where this is running.
       shared_rubocop_file = File.expand_path('../../.rubocop.yml', File.dirname(__FILE__))
       dest_file = "#{File.expand_path(@base_dir)}/.rubocop.yml"
-      if shared_rubocop_file != dest_file
+      if !File.exist?(dest_file)
         FileUtils.copy(shared_rubocop_file, dest_file)
+      elsif File.read(shared_rubocop_file) != File.read(dest_file)
+        puts "Using specific custom .rubocop.yml rather than the OpenStudio-measure-tester-gem's one"
       end
 
       puts "Current directory is #{@base_dir}"

--- a/lib/openstudio_measure_tester/runner.rb
+++ b/lib/openstudio_measure_tester/runner.rb
@@ -156,6 +156,9 @@ module OpenStudioMeasureTester
         # output_path: 'junk.xml',
         auto_correct: auto_correct,
         color: false,
+        # cf #76 - Because we pass a glob to the Runner.run, we must pass
+        # force_exclusion to respect the files excluded in the .rubocop.yml
+        force_exclusion: true,
         formatters: ['simple', ['RuboCop::Formatter::CheckstyleFormatter', rubocop_results_file]]
       }
 

--- a/spec/github_actions_report_spec.rb
+++ b/spec/github_actions_report_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# *******************************************************************************
+# OpenStudio(R), Copyright (c) Alliance for Sustainable Energy, LLC.
+# See also https://openstudio.net/license
+# *******************************************************************************
+
+RSpec.describe OpenStudioMeasureTester::MinitestResult do
+  it 'should produce a markdown table' do
+    dir = 'spec/files'
+    gha_reporter = OpenStudioMeasureTester::GithubActionsReport.new(dir)
+    gha_reporter.make_minitest_step_summary_table
+
+    expected = [
+       "| Metric           | Value  |",
+       "| ---------------- | ------ |",
+       "| Total Tests      | 16     |",
+       "| Load Error       | 0      |",
+       "| Passed           | 13     |",
+       "| Success Rate     | 86.67% |",
+       "| Failures         | 1      |",
+       "| Errors           | 1      |",
+       "| Skipped          | 1      |",
+       "| Incompatible     | 1      |",
+       "| Total Assertions | 120    |",
+    ]
+
+    expect(gha_reporter.minitest_summary_table).to eq expected.join("\n")
+  end
+end
+
+RSpec.describe OpenStudioMeasureTester::MinitestResult do
+  it 'should produce annotations' do
+    dir = 'spec/files'
+    gha_reporter = OpenStudioMeasureTester::GithubActionsReport.new(dir)
+    gha_reporter.make_minitest_annotations
+
+    expect(gha_reporter.all_annotations.size).to eq 3
+  end
+end

--- a/spec/rubocop_results_spec.rb
+++ b/spec/rubocop_results_spec.rb
@@ -25,4 +25,17 @@ RSpec.describe OpenStudioMeasureTester::RubocopResult do
     mr = OpenStudioMeasureTester::RubocopResult.new(dir)
     expect(File.exist?(write_file)).to be true
   end
+
+  it 'should not double count measures with a common substring' do
+    dir = 'spec/files/rubocop/common_substring'
+    mr = OpenStudioMeasureTester::RubocopResult.new(dir)
+
+    expect(mr.error_status).to eq true
+    expect(mr.total_files).to eq 2
+    expect(mr.total_measures).to eq 2
+    expect(mr.total_info).to eq 0
+    expect(mr.total_warnings).to eq 0
+    expect(mr.total_errors).to eq 1
+    expect(mr.total_issues).to eq 1
+  end
 end


### PR DESCRIPTION
Styling could be improved, more metrics from the rubocop + OpenStudio Style could be added. But this is good proof of concept, and I needed it for another project.

---

Example run (this is on a private repo...):

## Step summary on workflow run
![image](https://github.com/NREL/OpenStudio-measure-tester-gem/assets/5479063/53c4632c-909c-4e5f-987c-6733ecc0a866)

# Annotations on workflow run
![image](https://github.com/NREL/OpenStudio-measure-tester-gem/assets/5479063/04770563-addf-4ff2-9fb2-3ed403f2b511)

# Annotations on diffs
![image](https://github.com/NREL/OpenStudio-measure-tester-gem/assets/5479063/1dcb2581-8521-403a-9e85-3dc97f47e017)
